### PR TITLE
Verify page request (fixes #14)

### DIFF
--- a/Sources/App/Framework/Controllers/Database/PagedListController.swift
+++ b/Sources/App/Framework/Controllers/Database/PagedListController.swift
@@ -36,7 +36,7 @@ extension PagedListController {
 
     func list(_ req: Request) async throws -> Page<DatabaseModel> {
         let queryBuilder = DatabaseModel.query(on: req.db)
-        let list = try await beforeList(req, queryBuilder).paginate(for: req)
+        let list = try await beforeList(req, queryBuilder).paginate(req.pageRequest)
         return try await afterList(req, list)
     }
 }

--- a/Sources/App/Framework/Controllers/Database/Repository/PagedListController+Repository.swift
+++ b/Sources/App/Framework/Controllers/Database/Repository/PagedListController+Repository.swift
@@ -14,7 +14,7 @@ extension PagedListController where Self: DatabaseRepositoryController {
             // only select the id field and return each id only once
             .field(\._$id)
             .unique()
-            .paginate(for: req)
+            .paginate(req.pageRequest)
         return try await afterList(req, list)
     }
 }

--- a/Sources/App/Framework/Extensions/Request+PageRequest.swift
+++ b/Sources/App/Framework/Extensions/Request+PageRequest.swift
@@ -4,7 +4,9 @@ import Vapor
 extension Request {
     var pageRequest: PageRequest {
         get throws {
-            let pageRequest = try query.decode(PageRequest.self)
+            guard let pageRequest = try? query.decode(PageRequest.self) else {
+                throw Abort(.badRequest, reason: #"Could not decode page request. Make sure "per" and "page" are integers."#)
+            }
             return PageRequest(page: max(pageRequest.page, 1), per: max(pageRequest.per, 1))
         }
     }

--- a/Sources/App/Modules/Api/Controllers/Repository/Report/ApiRepositoryListUnverifiedReportsController.swift
+++ b/Sources/App/Modules/Api/Controllers/Repository/Report/ApiRepositoryListUnverifiedReportsController.swift
@@ -49,7 +49,7 @@ extension ApiRepositoryListUnverifiedReportsController {
             .query(on: req.db)
             .filter(\._$verifiedAt == nil)
             .sort(\._$updatedAt, .ascending) // oldest first
-            .paginate(for: req)
+            .paginate(req.pageRequest)
 
         return try await listUnverifiedReportsOutput(req, repository, unverifiedReports)
     }

--- a/Sources/App/Modules/Api/Controllers/Repository/Verification/ApiListRepositoriesWithUnverifiedDetailsController.swift
+++ b/Sources/App/Modules/Api/Controllers/Repository/Verification/ApiListRepositoriesWithUnverifiedDetailsController.swift
@@ -63,7 +63,7 @@ extension ApiListRepositoriesWithUnverifiedDetailsController {
 
         let repositoriesWithUnverifiedModelsQuery = DatabaseModel.query(on: req.db)
 
-        let repositoriesWithUnverifiedModels = try await beforeGetRepositories(req, repositoriesWithUnverifiedModelsQuery).paginate(for: req)
+        let repositoriesWithUnverifiedModels = try await beforeGetRepositories(req, repositoriesWithUnverifiedModelsQuery).paginate(req.pageRequest)
 
         return try await listRepositoriesWithUnverifiedDetailsOutput(req, repositoriesWithUnverifiedModels)
     }

--- a/Sources/App/Modules/Api/Controllers/Repository/Verification/ApiRepositoryListUnverifiedDetailsController.swift
+++ b/Sources/App/Modules/Api/Controllers/Repository/Verification/ApiRepositoryListUnverifiedDetailsController.swift
@@ -63,7 +63,7 @@ extension ApiRepositoryListUnverifiedDetailsController {
             .filter(LanguageModel.self, \.$priority != nil)
             .sort(\._$updatedAt, .ascending) // oldest first
 
-        let unverifiedDetails = try await beforeGetUnverifiedDetail(req, unverifiedDetailsQuery).paginate(for: req)
+        let unverifiedDetails = try await beforeGetUnverifiedDetail(req, unverifiedDetailsQuery).paginate(req.pageRequest)
 
         return try await listUnverifiedDetailsOutput(req, repository, unverifiedDetails)
     }

--- a/Sources/App/Modules/Tag/Controllers/MediaApiController+Tag.swift
+++ b/Sources/App/Modules/Tag/Controllers/MediaApiController+Tag.swift
@@ -130,14 +130,14 @@ extension MediaApiController {
 
     // MARK: list unverified tags
 
-    func listUnverifiedTags(_ req: Request) async throws -> [Tag.Repository.ListUnverifiedRelation] {
+    func listUnverifiedTags(_ req: Request) async throws -> Fluent.Page<Tag.Repository.ListUnverifiedRelation> {
         try await req.onlyFor(.moderator)
         let repository = try await repository(req)
 
         let unverifiedTags = try await repository.$tags.$pivots
             .query(on: req.db)
             .filter(\.$status ~~ [.pending, .deleteRequested])
-            .all()
+            .paginate(for: req)
 
         return try await unverifiedTags.concurrentMap { tag in
             let repository = try await tag.$tag.get(on: req.db)

--- a/Sources/App/Modules/Tag/Controllers/MediaApiController+Tag.swift
+++ b/Sources/App/Modules/Tag/Controllers/MediaApiController+Tag.swift
@@ -137,7 +137,7 @@ extension MediaApiController {
         let unverifiedTags = try await repository.$tags.$pivots
             .query(on: req.db)
             .filter(\.$status ~~ [.pending, .deleteRequested])
-            .paginate(for: req)
+            .paginate(req.pageRequest)
 
         return try await unverifiedTags.concurrentMap { tag in
             let repository = try await tag.$tag.get(on: req.db)

--- a/Sources/App/Modules/Tag/Controllers/WaypointApiController+Tag.swift
+++ b/Sources/App/Modules/Tag/Controllers/WaypointApiController+Tag.swift
@@ -136,14 +136,14 @@ extension WaypointApiController {
 
     // MARK: list unverified tags
 
-    func listUnverifiedTags(_ req: Request) async throws -> [Tag.Repository.ListUnverifiedRelation] {
+    func listUnverifiedTags(_ req: Request) async throws -> Fluent.Page<Tag.Repository.ListUnverifiedRelation> {
         try await req.onlyFor(.moderator)
         let repository = try await repository(req)
 
         let unverifiedTags = try await repository.$tags.$pivots
             .query(on: req.db)
             .filter(\.$status ~~ [.pending, .deleteRequested])
-            .all()
+            .paginate(for: req)
 
         return try await unverifiedTags.concurrentMap { tag in
             let repository = try await tag.$tag.get(on: req.db)

--- a/Sources/App/Modules/Tag/Controllers/WaypointApiController+Tag.swift
+++ b/Sources/App/Modules/Tag/Controllers/WaypointApiController+Tag.swift
@@ -143,7 +143,7 @@ extension WaypointApiController {
         let unverifiedTags = try await repository.$tags.$pivots
             .query(on: req.db)
             .filter(\.$status ~~ [.pending, .deleteRequested])
-            .paginate(for: req)
+            .paginate(req.pageRequest)
 
         return try await unverifiedTags.concurrentMap { tag in
             let repository = try await tag.$tag.get(on: req.db)

--- a/Sources/App/Modules/Waypoint/Controllers/WaypointApiController+Verify.swift
+++ b/Sources/App/Modules/Waypoint/Controllers/WaypointApiController+Verify.swift
@@ -123,7 +123,7 @@ extension WaypointApiController: ApiRepositoryVerificationController {
             .query(on: req.db)
             .filter(\.$verifiedAt == nil)
             .sort(\.$updatedAt, .ascending) // oldest first
-            .paginate(for: req)
+            .paginate(req.pageRequest)
 
         return try unverifiedLocations.map { location in
             try .init(

--- a/Sources/AppApi/Documentation.docc/Api/Redirect/RedirectDetail.md
+++ b/Sources/AppApi/Documentation.docc/Api/Redirect/RedirectDetail.md
@@ -4,7 +4,7 @@ Gets a redirect for redirect id.
 
 ## Request
 
-    GET /api/v1/redirect/<redirect-id>
+    GET /api/v1/redirects/<redirect-id>
 
 This endpoint is only available to admins.
 

--- a/Sources/AppApi/Documentation.docc/Api/Redirect/RedirectList.md
+++ b/Sources/AppApi/Documentation.docc/Api/Redirect/RedirectList.md
@@ -4,7 +4,7 @@ Lists all redirects in pages.
 
 ## Request
 
-    GET /api/v1/redirect
+    GET /api/v1/redirects
 
 This endpoint is only available to admins.
 

--- a/Sources/AppApi/Documentation.docc/Api/User/Password/UserChangePassword.md
+++ b/Sources/AppApi/Documentation.docc/Api/User/Password/UserChangePassword.md
@@ -4,7 +4,7 @@ Updates the password for a user.
 
 ## Request
 
-    PUT /api/v1/users/accounts/<user-id>/updatePassword
+    PUT /api/v1/user/accounts/<user-id>/updatePassword
 
 This endpoint is only available to the user himself.
 

--- a/Sources/AppApi/Documentation.docc/Api/User/Password/UserRequestResetPassword.md
+++ b/Sources/AppApi/Documentation.docc/Api/User/Password/UserRequestResetPassword.md
@@ -4,7 +4,7 @@ Requests a link with which to reset the user password when it was forgotten.
 
 ## Request
 
-    POST /api/v1/users/accounts/resetPassword
+    POST /api/v1/user/accounts/resetPassword
 
 ### Input parameters
 

--- a/Sources/AppApi/Documentation.docc/Api/User/Password/UserResetPassword.md
+++ b/Sources/AppApi/Documentation.docc/Api/User/Password/UserResetPassword.md
@@ -4,7 +4,7 @@ Resets the user password when it has been forgotten.
 
 ## Request
 
-    POST /api/v1/users/accounts/<user-id>/resetPassword
+    POST /api/v1/user/accounts/<user-id>/resetPassword
 
 The verification token the user received has to be sent as a `BearerToken` with the request.
 

--- a/Sources/AppApi/Documentation.docc/Api/User/UserChangeRole.md
+++ b/Sources/AppApi/Documentation.docc/Api/User/UserChangeRole.md
@@ -4,7 +4,7 @@ Assigns a new role to a user.
 
 ## Request
 
-    PUT /api/v1/users/accounts/<user-id>/changeRole
+    PUT /api/v1/user/accounts/<user-id>/changeRole
 
 This endpoint is only available to admins.
 

--- a/Sources/AppApi/Documentation.docc/Api/User/UserCreate.md
+++ b/Sources/AppApi/Documentation.docc/Api/User/UserCreate.md
@@ -4,7 +4,7 @@ Creates a new user.
 
 ## Request
 
-    POST /api/v1/users/accounts
+    POST /api/v1/user/accounts
 
 ### Input parameters
 

--- a/Sources/AppApi/Documentation.docc/Api/User/UserDelete.md
+++ b/Sources/AppApi/Documentation.docc/Api/User/UserDelete.md
@@ -4,7 +4,7 @@ Deletes a user.
 
 ## Request
 
-    DELETE /api/v1/users/accounts/<user-id>
+    DELETE /api/v1/user/accounts/<user-id>
 
 This endpoint is only available to the user himself and admins.
 

--- a/Sources/AppApi/Documentation.docc/Api/User/UserDetail.md
+++ b/Sources/AppApi/Documentation.docc/Api/User/UserDetail.md
@@ -4,7 +4,7 @@ Gets a user detail object for the user id.
 
 ## Request
 
-    GET /api/v1/users/accounts/<user-id>
+    GET /api/v1/user/accounts/<user-id>
 
 ## Response
 

--- a/Sources/AppApi/Documentation.docc/Api/User/UserDetailSelf.md
+++ b/Sources/AppApi/Documentation.docc/Api/User/UserDetailSelf.md
@@ -4,7 +4,7 @@ Gets the detail object for the own user.
 
 ## Request
 
-    GET /api/v1/users/accounts/me
+    GET /api/v1/user/accounts/me
 
 This endpoint is only available when a `BearerToken` is sent with the request. It will always return the user for this token.
 

--- a/Sources/AppApi/Documentation.docc/Api/User/UserList.md
+++ b/Sources/AppApi/Documentation.docc/Api/User/UserList.md
@@ -4,7 +4,7 @@ Lists all users in pages.
 
 ## Request 
 
-    GET /api/v1/users/accounts
+    GET /api/v1/user/accounts
 
 This endpoint is only available to admins.
 

--- a/Sources/AppApi/Documentation.docc/Api/User/UserPatch.md
+++ b/Sources/AppApi/Documentation.docc/Api/User/UserPatch.md
@@ -4,7 +4,7 @@ Patches an existing user from the given input.
 
 ## Request
 
-    PATCH /api/v1/users/accounts/<user-id>
+    PATCH /api/v1/user/accounts/<user-id>
 
 This endpoint is only available to the user himself and admins.
 

--- a/Sources/AppApi/Documentation.docc/Api/User/UserUpdate.md
+++ b/Sources/AppApi/Documentation.docc/Api/User/UserUpdate.md
@@ -4,7 +4,7 @@ Updates an existing user from the given input.
 
 ## Request 
 
-    PUT /api/v1/users/accounts/<user-id>
+    PUT /api/v1/user/accounts/<user-id>
 
 This endpoint is only available to the user himself and admins.
 

--- a/Sources/AppApi/Documentation.docc/Api/User/Verification/UserRequestVerifyEmail.md
+++ b/Sources/AppApi/Documentation.docc/Api/User/Verification/UserRequestVerifyEmail.md
@@ -4,7 +4,7 @@ Requests a verification token for the user's email address.
 
 ## Request
 
-    POST /api/v1/users/accounts/<user-id>/requestVerification
+    POST /api/v1/user/accounts/<user-id>/requestVerification
 
 This endpoint is only available to the user himself and the email cannot yet be verified.
 

--- a/Tests/AppTests/Pagination/PaginationApiTests.swift
+++ b/Tests/AppTests/Pagination/PaginationApiTests.swift
@@ -55,7 +55,7 @@ final class PaginationApiTests: AppTestCase, MediaTest, WaypointTest, TagTest {
             "/api/v1/tags/\(tagRepositoryId)/reports/unverified": nil,
             "/api/v1/user/accounts": nil,
             "/api/v1/staticContent": nil,
-            "/api/v1/redirects": nil
+            "/api/v1/redirects": nil,
         ]
     }
 

--- a/Tests/AppTests/Pagination/PaginationApiTests.swift
+++ b/Tests/AppTests/Pagination/PaginationApiTests.swift
@@ -1,0 +1,103 @@
+import Fluent
+import Spec
+import XCTVapor
+@testable import App
+
+final class PaginationApiTests: AppTestCase, MediaTest, WaypointTest, TagTest {
+    enum ModelType {
+        case mediaRepository
+        case waypointRepository
+        case tag
+        case tagRepository
+    }
+
+    func idFor(_ modelType: ModelType) async throws -> String {
+        switch modelType {
+        case .mediaRepository:
+            return try await createNewMedia().repository.requireID().uuidString
+        case .waypointRepository:
+            return try await createNewWaypoint().repository.requireID().uuidString
+        case .tag:
+            return try await createNewTag().detail.requireID().uuidString
+        case .tagRepository:
+            return try await createNewTag().repository.requireID().uuidString
+        }
+    }
+
+    func getPaginatedEndpoints() async throws -> [String: [String: Any]?] {
+        async let mediaRepositoryId = idFor(.mediaRepository)
+        async let waypointRepositoryId = idFor(.waypointRepository)
+        async let tagId = idFor(.tag)
+        async let tagRepositoryId = idFor(.tagRepository)
+
+        return try await [
+            "/api/v1/media": nil,
+            "/api/v1/media/search": ["languageCode": "de", "text": "test"],
+            "/api/v1/media/unverified": nil,
+            "/api/v1/media/\(mediaRepositoryId)/unverified": nil,
+            "/api/v1/media/\(mediaRepositoryId)/reports/unverified": nil,
+            "/api/v1/media/\(mediaRepositoryId)/tags/unverified": nil,
+            "/api/v1/waypoints": nil,
+            "/api/v1/waypoints/\(waypointRepositoryId)/media": nil,
+            "/api/v1/waypoints/search": ["languageCode": "de", "text": "test"],
+            "/api/v1/waypoints/in": ["topLeftLatitude": 5, "topLeftLongitude": 5, "bottomRightLatitude": 0, "bottomRightLongitude": 10],
+            "/api/v1/waypoints/unverified": nil,
+            "/api/v1/waypoints/\(waypointRepositoryId)/waypoints/unverified": nil,
+            "/api/v1/waypoints/\(waypointRepositoryId)/locations/unverified": nil,
+            "/api/v1/waypoints/\(waypointRepositoryId)/reports/unverified": nil,
+            "/api/v1/waypoints/\(waypointRepositoryId)/tags/unverified": nil,
+            "/api/v1/tags": nil,
+            "/api/v1/tags/search": ["languageCode": "de", "text": "test"],
+            "/api/v1/tags/\(tagId)/media": nil,
+            "/api/v1/tags/\(tagId)/waypoints": nil,
+            "/api/v1/tags/unverified": nil,
+            "/api/v1/tags/\(tagRepositoryId)/unverified": nil,
+            "/api/v1/tags/\(tagRepositoryId)/reports/unverified": nil,
+            "/api/v1/user/accounts": nil,
+            "/api/v1/staticContent": nil,
+            "/api/v1/redirects": nil
+        ]
+    }
+
+    func serialize(_ parameters: [String: Any]?) -> String {
+        guard let parameters else { return "" }
+        return parameters.map { "\($0.key)=\($0.value)" }
+            .joined(separator: "&")
+    }
+
+    func testPaginationPerFieldNeedsValidValue() async throws {
+        async let paginatedEndpoints = getPaginatedEndpoints()
+        async let token = getToken(for: .admin)
+
+        for endpoint in try await paginatedEndpoints {
+            var queryParameters = endpoint.value ?? [:]
+            queryParameters["per"] = "hi"
+            let serializedParameters = "?\(serialize(queryParameters))"
+
+            try await app
+                .describe("Per parameter in page request should be validated")
+                .get(endpoint.key.appending(serializedParameters))
+                .bearerToken(token)
+                .expect(.badRequest)
+                .test()
+        }
+    }
+
+    func testPaginationPageFieldNeedsValidValue() async throws {
+        async let paginatedEndpoints = getPaginatedEndpoints()
+        async let token = getToken(for: .admin)
+
+        for endpoint in try await paginatedEndpoints {
+            var queryParameters = endpoint.value ?? [:]
+            queryParameters["page"] = "hi"
+            let serializedParameters = "?\(serialize(queryParameters))"
+
+            try await app
+                .describe("Per parameter in page request should be validated")
+                .get(endpoint.key.appending(serializedParameters))
+                .bearerToken(token)
+                .expect(.badRequest)
+                .test()
+        }
+    }
+}

--- a/Tests/AppTests/Tag/Media/MediaApiListUnverifiedTagsTests.swift
+++ b/Tests/AppTests/Tag/Media/MediaApiListUnverifiedTagsTests.swift
@@ -16,9 +16,9 @@ final class MediaApiListUnverifiedTagsTests: AppTestCase, MediaTest, TagTest {
             .bearerToken(moderatorToken)
             .expect(.ok)
             .expect(.json)
-            .expect([Tag.Repository.ListUnverifiedRelation].self) { content in
-                XCTAssert(content.contains { $0.tagId == tag.repository.id! })
-                if let responseTag = content.first(where: { $0.tagId == tag.repository.id! }) {
+            .expect(AppApi.Page<Tag.Repository.ListUnverifiedRelation>.self) { content in
+                XCTAssert(content.items.contains { $0.tagId == tag.repository.id! })
+                if let responseTag = content.items.first(where: { $0.tagId == tag.repository.id! }) {
                     XCTAssertEqual(responseTag.title, tag.detail.title)
                     XCTAssertEqual(responseTag.status, .pending)
                 }
@@ -45,9 +45,9 @@ final class MediaApiListUnverifiedTagsTests: AppTestCase, MediaTest, TagTest {
             .bearerToken(moderatorToken)
             .expect(.ok)
             .expect(.json)
-            .expect([Tag.Repository.ListUnverifiedRelation].self) { content in
-                XCTAssert(content.contains { $0.tagId == tag.repository.id! })
-                if let responseTag = content.first(where: { $0.tagId == tag.repository.id! }) {
+            .expect(AppApi.Page<Tag.Repository.ListUnverifiedRelation>.self) { content in
+                XCTAssert(content.items.contains { $0.tagId == tag.repository.id! })
+                if let responseTag = content.items.first(where: { $0.tagId == tag.repository.id! }) {
                     XCTAssertEqual(responseTag.title, tag.detail.title)
                     XCTAssertEqual(responseTag.status, .deleteRequested)
                 }
@@ -74,8 +74,8 @@ final class MediaApiListUnverifiedTagsTests: AppTestCase, MediaTest, TagTest {
             .bearerToken(moderatorToken)
             .expect(.ok)
             .expect(.json)
-            .expect([Tag.Repository.ListUnverifiedRelation].self) { content in
-                XCTAssert(!content.contains { $0.tagId == tag.repository.id! })
+            .expect(AppApi.Page<Tag.Repository.ListUnverifiedRelation>.self) { content in
+                XCTAssert(!content.items.contains { $0.tagId == tag.repository.id! })
             }
             .test()
     }

--- a/Tests/AppTests/Tag/Waypoint/WaypointApiListUnverifiedTagsTests.swift
+++ b/Tests/AppTests/Tag/Waypoint/WaypointApiListUnverifiedTagsTests.swift
@@ -16,9 +16,9 @@ final class WaypointApiListUnverifiedTagsTests: AppTestCase, WaypointTest, TagTe
             .bearerToken(moderatorToken)
             .expect(.ok)
             .expect(.json)
-            .expect([Tag.Repository.ListUnverifiedRelation].self) { content in
-                XCTAssert(content.contains { $0.tagId == tag.repository.id! })
-                if let responseTag = content.first(where: { $0.tagId == tag.repository.id! }) {
+            .expect(AppApi.Page<Tag.Repository.ListUnverifiedRelation>.self) { content in
+                XCTAssert(content.items.contains { $0.tagId == tag.repository.id! })
+                if let responseTag = content.items.first(where: { $0.tagId == tag.repository.id! }) {
                     XCTAssertEqual(responseTag.title, tag.detail.title)
                     XCTAssertEqual(responseTag.status, .pending)
                 }
@@ -45,9 +45,9 @@ final class WaypointApiListUnverifiedTagsTests: AppTestCase, WaypointTest, TagTe
             .bearerToken(moderatorToken)
             .expect(.ok)
             .expect(.json)
-            .expect([Tag.Repository.ListUnverifiedRelation].self) { content in
-                XCTAssert(content.contains { $0.tagId == tag.repository.id! })
-                if let responseTag = content.first(where: { $0.tagId == tag.repository.id! }) {
+            .expect(AppApi.Page<Tag.Repository.ListUnverifiedRelation>.self) { content in
+                XCTAssert(content.items.contains { $0.tagId == tag.repository.id! })
+                if let responseTag = content.items.first(where: { $0.tagId == tag.repository.id! }) {
                     XCTAssertEqual(responseTag.title, tag.detail.title)
                     XCTAssertEqual(responseTag.status, .deleteRequested)
                 }
@@ -74,8 +74,8 @@ final class WaypointApiListUnverifiedTagsTests: AppTestCase, WaypointTest, TagTe
             .bearerToken(moderatorToken)
             .expect(.ok)
             .expect(.json)
-            .expect([Tag.Repository.ListUnverifiedRelation].self) { content in
-                XCTAssert(!content.contains { $0.tagId == tag.repository.id! })
+            .expect(AppApi.Page<Tag.Repository.ListUnverifiedRelation>.self) { content in
+                XCTAssert(!content.items.contains { $0.tagId == tag.repository.id! })
             }
             .test()
     }


### PR DESCRIPTION
Verify "per" and "page" query parameters sent with a page request. Return status code 400 bad request when an invalid value is provided instead of 500 internal server error